### PR TITLE
Surface all headers into CPTData structure

### DIFF
--- a/src/pygef/broxml/parse_cpt.py
+++ b/src/pygef/broxml/parse_cpt.py
@@ -59,7 +59,7 @@ CPT_ATTRIBS = {
     "column_void_mapping": {
         "xpath": "./dummyTag",
     },
-    "headers": {
+    "raw_headers": {
         "xpath": "./dummyTag",
     },
     "data": {

--- a/src/pygef/cpt.py
+++ b/src/pygef/cpt.py
@@ -56,7 +56,7 @@ class CPTData:
         zlm_pore_pressure_u2_after (float | None): zlm_pore_pressure_u2_after
         zlm_pore_pressure_u3_after (float | None): zlm_pore_pressure_u3_after
         column_void_mapping (dict | None): column_void_mapping
-        headers (dict | None): headers
+        raw_headers (dict): headers
         data (pl.DataFrame): DataFrame
             columns:
 
@@ -141,10 +141,10 @@ class CPTData:
     delivered_vertical_position_datum: VerticalDatumClass
     delivered_vertical_position_reference_point: str
     column_void_mapping: dict | None
-    headers: dict | None
     data: pl.DataFrame
 
     alias: str | None = field(default=None)
+    raw_headers: dict = field(default_factory=dict)
 
     def __post_init__(self):
         # post-processing of the data

--- a/src/pygef/shim.py
+++ b/src/pygef/shim.py
@@ -130,7 +130,7 @@ def gef_cpt_to_cpt_data(gef_cpt: _GefCpt) -> CPTData:
     kwargs["alias"] = gef_cpt.test_id
     kwargs["data"] = gef_cpt.df
     kwargs["column_void_mapping"] = gef_cpt.columns_info.description_to_void_mapping
-    kwargs["headers"] = gef_cpt._headers
+    kwargs["raw_headers"] = gef_cpt._headers
     kwargs["research_report_date"] = gef_cpt.file_date
     kwargs["cpt_standard"] = None
     kwargs["groundwater_level"] = gef_cpt.groundwater_level

--- a/tests/gef/test_gef.py
+++ b/tests/gef/test_gef.py
@@ -9,7 +9,6 @@ import numpy as np
 import polars as pl
 import polars.testing as pl_test
 import pytest
-from numpy.ma.testutils import assert_equal
 
 import pygef.gef.utils as utils
 from pygef import common, exceptions, plotting, read_bore, read_cpt
@@ -711,8 +710,8 @@ def test_parse_cpt_headers():
 1.0600e+000 6.9000e-001 3.9000e-002
 """
     )
-    assert len(cpt.headers) == 15
-    assert cpt.headers["MEASUREMENTTEXT"][0][1] == "030919"
+    assert len(cpt.raw_headers) == 15
+    assert cpt.raw_headers["MEASUREMENTTEXT"][0][1] == "030919"
 
 
 def test_parse_cpt_with_replace_column_voids_enabled():

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -84,7 +84,7 @@ def test_gef_to_cpt_data(_type, cpt_gef_1, cpt_gef_1_bytes, cpt_gef_1_string) ->
         "zlm_pore_pressure_u2_before": -0.028,
         "zlm_pore_pressure_u3_after": None,
         "zlm_pore_pressure_u3_before": None,
-        "headers": {
+        "raw_headers": {
             "COLUMN": [["10"]],
             "COLUMNINFO": [
                 ["1", "m", "Sondeerlengte", "1"],


### PR DESCRIPTION
Provides a new 'headers' attribute on the CPTData which is returned to applications processing GEF files. This allows those apps that need it to access all the headers context directly.

Closes #448