### PR TITLE
pygef#450: discard or retain "pre excavated" range measurements

### DIFF
--- a/src/pygef/shim.py
+++ b/src/pygef/shim.py
@@ -64,6 +64,7 @@ def read_cpt(
     index: int = 0,
     engine: Literal["auto", "gef", "xml"] = "auto",
     replace_column_voids: bool = True,
+    remove_pre_excavated_rows: bool = True,
 ) -> CPTData:
     """
     Parse the cpt file. Can either be BytesIO, Path or str
@@ -74,6 +75,8 @@ def read_cpt(
         Please note that auto engine checks if the files starts with `#GEFID`.
     :param replace_column_voids: default True. How to handle rows with void values.
         If true, replace void values with nulls or interpolate; else retain value.
+    :param remove_pre_excavated_rows: default True. How to handle pre-excavated row values.
+        If true, drop rows above pre-excavated depth; else retain.
     """
 
     if engine == "gef" or is_gef_file(file) and engine == "auto":
@@ -84,15 +87,24 @@ def read_cpt(
                 _GefCpt(
                     string=file.read().decode(),
                     replace_column_voids=replace_column_voids,
+                    remove_pre_excavated_rows=remove_pre_excavated_rows,
                 )
             )
         if os.path.exists(file):
             return gef_cpt_to_cpt_data(
-                _GefCpt(path=file, replace_column_voids=replace_column_voids)
+                _GefCpt(
+                    path=file,
+                    replace_column_voids=replace_column_voids,
+                    remove_pre_excavated_rows=remove_pre_excavated_rows,
+                )
             )
         else:
             return gef_cpt_to_cpt_data(
-                _GefCpt(string=file, replace_column_voids=replace_column_voids)
+                _GefCpt(
+                    string=file,
+                    replace_column_voids=replace_column_voids,
+                    remove_pre_excavated_rows=remove_pre_excavated_rows,
+                )
             )
     return read_cpt_xml(file)[index]
 

--- a/tests/test_files/cpt_pre_excavated.gef
+++ b/tests/test_files/cpt_pre_excavated.gef
@@ -1,0 +1,14 @@
+#GEFID= 1, 1, 0
+#TESTID= GEF with pre-excavated depth
+#COLUMNINFO=1,m,penetrationLength,1
+#COLUMNINFO=2,kN,coneResistance,2
+#REPORTCODE= GEF-CPT-Report, 1, 1, 2, -
+#PROCEDURECODE= GEF-CPT-Report, 1, 0, 0, -
+#XYID= 31000, 79578.38, 424838.97, 0.02, 0.02
+#ZID= 31000, -0.09, 0.05
+#MEASUREMENTVAR=13,1.500000,m,Pre-excavated depth
+#RECORDSEPARATOR=!
+#COLUMNSEPARATOR=;
+#EOH=
+0.5;10.0;!
+2.0;15.0;!


### PR DESCRIPTION
This PR addresses #450 by providing an optional parameter remove_pre_excavated_rows

If provided and set False, Pygef will not discard rows above the value set for "pre-excavated depth"